### PR TITLE
Make richtext configuration optional

### DIFF
--- a/Classes/Tca/Field/RteField.php
+++ b/Classes/Tca/Field/RteField.php
@@ -15,15 +15,15 @@ class RteField extends AbstractField
 
         $resolver->setDefaults([
             'dbType' => "MEDIUMTEXT DEFAULT NULL",
-            'richtextConfiguration' => 'default',
+            'richtextConfiguration' => null,
         ]);
 
-        $resolver->setAllowedTypes('richtextConfiguration', 'string');
+        $resolver->setAllowedTypes('richtextConfiguration', ['string', 'null']);
     }
 
     public function getFieldTcaConfig(TcaBuilderContext $tcaBuilder): array
     {
-        return [
+        $tcaConfig = [
             'type' => 'text',
 
             // rows and cols are ignored anyways unless rte is ignored
@@ -32,7 +32,12 @@ class RteField extends AbstractField
 
             'softref' => 'typolink_tag,images,email[subst],url',
             'enableRichtext' => true,
-            'richtextConfiguration' => $this->getOption('richtextConfiguration')
         ];
+
+        if ($this->getOption('richtextConfiguration')) {
+            $tcaConfig['richtextConfiguration'] = $this->getOption('richtextConfiguration');
+        }
+
+        return $tcaConfig;
     }
 }


### PR DESCRIPTION
make the richtext configuration fallback to the globally definied default config (RTE.deault.preset) if no explicitely defined